### PR TITLE
Update for MyBB 1.8.4 to conform to DB_Base.

### DIFF
--- a/Upload/inc/xthreads/xt_mischooks.php
+++ b/Upload/inc/xthreads/xt_mischooks.php
@@ -322,7 +322,7 @@ function xthreads_wol_patch_init(&$ua) {
 							$GLOBALS[\'thread_fid_map\'][$r[\'tid\']] = $r[\'fid\'];
 							return $r;
 						}
-						return parent::fetch_array($query);
+						return parent::fetch_array($query, $resulttype);
 					}
 				');
 				$db->xthreads_db_wol_hook = false;

--- a/Upload/inc/xthreads/xt_mischooks.php
+++ b/Upload/inc/xthreads/xt_mischooks.php
@@ -316,7 +316,7 @@ function xthreads_wol_patch_init(&$ua) {
 					';
 				
 				control_object($db, $hook.'
-					function fetch_array($query) {
+					function fetch_array($query, $resulttype=MYSQL_ASSOC) {
 						if($this->xthreads_db_wol_hook) {
 							$r = parent::fetch_array($query);
 							$GLOBALS[\'thread_fid_map\'][$r[\'tid\']] = $r[\'fid\'];

--- a/Upload/inc/xthreads/xt_sthreadhooks.php
+++ b/Upload/inc/xthreads/xt_sthreadhooks.php
@@ -198,7 +198,7 @@ function xthreads_showthread_firstpost() {
 					$this->xthreads_firstpost_hack = false;
 					return array(\'pid\' => $GLOBALS[\'thread\'][\'firstpost\']);
 				}
-				return parent::fetch_array($query);
+				return parent::fetch_array($query, $resulttype);
 			}
 		';
 		$firstpost_hack_code = 'if($options[\'limit_start\']) $this->xthreads_firstpost_hack = true;';

--- a/Upload/inc/xthreads/xt_sthreadhooks.php
+++ b/Upload/inc/xthreads/xt_sthreadhooks.php
@@ -193,7 +193,7 @@ function xthreads_showthread_firstpost() {
 		$GLOBALS['postcounter'] = '-0';
 		
 		$extra_code = '
-			function fetch_array($query) {
+			function fetch_array($query, $resulttype=MYSQL_ASSOC) {
 				if($this->xthreads_firstpost_hack) {
 					$this->xthreads_firstpost_hack = false;
 					return array(\'pid\' => $GLOBALS[\'thread\'][\'firstpost\']);


### PR DESCRIPTION
MyBB 1.8 introduced a new parameter to `DB_*::fetch_array()`, which was not included in the `control_object()` alterations made to the global `$db` object. In MyBB 1.8.4, all DB classes must conform to the contract defined by the interface `DB_Base`, which led to errors.
